### PR TITLE
Minlopro: Per-User Named Credentials

### DIFF
--- a/src/minlopro/main/classes/auth-provider-plugins/AuthProviderPluginsPlayground.cls
+++ b/src/minlopro/main/classes/auth-provider-plugins/AuthProviderPluginsPlayground.cls
@@ -8,6 +8,10 @@ public with sharing class AuthProviderPluginsPlayground {
         this.runClientCredentialsFlow();
         this.runWedServerWithPkceFlow();
         this.runJwtFlow();
+        Logger.debug(
+            'Consumed {0} callouts out of {1} limit.',
+            Lists.of(Limits.getCallouts().toString(), Limits.getLimitCallouts().toString())
+        );
     }
 
     public void runClientCredentialsFlow() {

--- a/src/minlopro/main/classes/per-user-named-credential/PerUserNamedCredentialController.cls
+++ b/src/minlopro/main/classes/per-user-named-credential/PerUserNamedCredentialController.cls
@@ -1,0 +1,89 @@
+public with sharing class PerUserNamedCredentialController {
+    @AuraEnabled(Cacheable=true)
+    public static List<NamedCredential> getNamedCredentials() {
+        return [
+            SELECT Id, MasterLabel, DeveloperName, PrincipalType
+            FROM NamedCredential
+            WHERE PrincipalType != NULL
+            LIMIT 5
+        ];
+    }
+
+    @AuraEnabled
+    public static String getDataUserAuthUrl(String namedCredentialApiName) {
+        // Inspired by https://salesforce.stackexchange.com/questions/214981/is-it-possible-to-set-per-user-named-credentials-via-apex
+        try {
+            List<ExternalDataUserAuth> existingDataUserAuths = [
+                SELECT Id
+                FROM ExternalDataUserAuth
+                WHERE
+                    ExternalDataSourceId IN (SELECT Id FROM NamedCredential WHERE DeveloperName = :namedCredentialApiName)
+                    AND UserId = :UserInfo.getUserId()
+                LIMIT 1
+            ];
+            if (!existingDataUserAuths.isEmpty()) {
+                return String.format('/{0}/e', Lists.of(existingDataUserAuths[0].Id));
+            }
+            String prefix = ExternalDataUserAuth.getSObjectType().getDescribe().getKeyPrefix();
+            return String.format('/{0}/e', Lists.of(prefix));
+        } catch (Exception rootException) {
+            Logger.error(rootException);
+            AuraHandledException auraEx = new AuraHandledException(rootException.getMessage());
+            auraEx.initCause(rootException);
+            throw new AuraHandledException(rootException.getMessage());
+        }
+    }
+
+    @AuraEnabled
+    public static CalloutResponse invoke(String namedCredentialApiName) {
+        try {
+            HttpRequest req = new HttpRequest();
+            String encodedQuery = EncodingUtil.urlEncode('SELECT Id, Name, InstanceName FROM Organization', 'UTF-8');
+            String endpoint = String.format(
+                'callout:{0}/services/data/v{1}/query?q={2}',
+                Lists.of(namedCredentialApiName, '60.0', encodedQuery)
+            );
+            req.setMethod('GET');
+            req.setEndpoint(endpoint);
+            HttpResponse resp = new Http().send(req);
+            return new CalloutResponse(resp);
+        } catch (Exception rootException) {
+            Logger.error(rootException);
+            AuraHandledException auraEx = new AuraHandledException(rootException.getMessage());
+            auraEx.initCause(rootException);
+            throw new AuraHandledException(rootException.getMessage());
+        }
+    }
+
+    public class CalloutResponse {
+        private final HttpResponse response;
+        @AuraEnabled
+        public String body {
+            get {
+                return this.response?.getBody();
+            }
+        }
+        @AuraEnabled
+        public String status {
+            get {
+                return this.response?.getStatus();
+            }
+        }
+        @AuraEnabled
+        public Integer statusCode {
+            get {
+                return this.response?.getStatusCode();
+            }
+        }
+        @AuraEnabled
+        public Boolean success {
+            get {
+                return this.statusCode == 200 || this.statusCode == 201;
+            }
+        }
+
+        public CalloutResponse(HttpResponse response) {
+            this.response = response;
+        }
+    }
+}

--- a/src/minlopro/main/classes/per-user-named-credential/PerUserNamedCredentialController.cls-meta.xml
+++ b/src/minlopro/main/classes/per-user-named-credential/PerUserNamedCredentialController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/minlopro/main/classes/rest-endpoints/GithubWebhookEndpoint.cls
+++ b/src/minlopro/main/classes/rest-endpoints/GithubWebhookEndpoint.cls
@@ -1,7 +1,7 @@
 @RestResource(UrlMapping='/github')
 global with sharing class GithubWebhookEndpoint {
     @TestVisible
-    private static String GITHUB_WEBHOOK_SECRET = '@SF_GITHUB_WEBHOOK_SECRET'; // Environment variable;
+    private static String GITHUB_WEBHOOK_SECRET = '@SF_GITHUB_WEBHOOK_SECRET';
     @TestVisible
     private static final String GITHUB_SIGNATURE_HEADER = 'X-Hub-Signature-256';
     @TestVisible

--- a/src/minlopro/main/classes/rest-endpoints/PublicRestEndpoint.cls
+++ b/src/minlopro/main/classes/rest-endpoints/PublicRestEndpoint.cls
@@ -10,7 +10,7 @@ global without sharing class PublicRestEndpoint {
      * Alternatively, use bash script "scripts/util/get_digex_site_url.sh" in order to get valid site URL.
      *
      * cURL command to use: [curl https://[your-site-domain]/services/apexrest/echo | jq .]
-     * e.g. curl https://energy-nosoftware-598.scratch.my.site.com/services/apexrest/echo | jq .
+     * e.g. curl @SF_SITE_URL/services/apexrest/echo | jq .
      * Note 'jq' utility usage - it simply prettifies output value to the console.
      *
      * @return Transaction information.

--- a/src/minlopro/main/classes/salesforce-connect-custom-adapter/MinloproContactsConnection.cls
+++ b/src/minlopro/main/classes/salesforce-connect-custom-adapter/MinloproContactsConnection.cls
@@ -31,7 +31,7 @@ global class MinloproContactsConnection extends DataSource.Connection {
     /**
      * This method is called everytime when SOQL is issued against external Object
      * or while using list view or viewing detail page.
-     * */
+     */
     override global DataSource.TableResult query(DataSource.QueryContext cx) {
         Logger.debug('query()');
         String targetTableName = cx.tableSelection.tableSelected;

--- a/src/minlopro/main/connectedApps/MinloproSalesforceLoopback.connectedApp-meta.xml
+++ b/src/minlopro/main/connectedApps/MinloproSalesforceLoopback.connectedApp-meta.xml
@@ -32,5 +32,5 @@
     </oauthPolicy>
     <permissionSetName>Minlopro - Admin</permissionSetName>
     <permissionSetName>Minlopro - Salesforce Connect Custom Adapter</permissionSetName>
-    <permissionSetName>Minlopro - Custom Auth.Providers And Named Credentials</permissionSetName>
+    <permissionSetName>Minlopro - Custom Auth. Providers And Named Credentials</permissionSetName>
 </ConnectedApp>

--- a/src/minlopro/main/lwc/perUserNamedCredentialTab/perUserNamedCredentialTab.html
+++ b/src/minlopro/main/lwc/perUserNamedCredentialTab/perUserNamedCredentialTab.html
@@ -1,0 +1,51 @@
+<template>
+    <lightning-card>
+        <span slot="title" class="slds-text-title_caps"><code>c-per-user-named-credential-tab</code></span>
+        <lightning-button-group slot="actions">
+            <lightning-button
+                label="Invoke Sample Callout"
+                variant="brand"
+                disabled={doDisableBtn}
+                onclick={handleInvokeCallout}
+            ></lightning-button>
+        </lightning-button-group>
+        <lightning-spinner lwc:if={loading} alternative-text="Loading" size="x-small"></lightning-spinner>
+        <lightning-layout multiple-rows>
+            <lightning-layout-item size="4" padding="horizontal-small">
+                <c-combobox
+                    label="Named Credential"
+                    value={selectedValue}
+                    options={namedCredentialOptions}
+                    required
+                    onchange={handleSelect}
+                ></c-combobox>
+                <lightning-badge
+                    lwc:if={selectedNamedCredential}
+                    label={selectedNamedCredential.PrincipalType}
+                    class="slds-badge_inverse slds-m-vertical_x-small"
+                ></lightning-badge>
+            </lightning-layout-item>
+            <lightning-layout-item size="8" padding="horizontal-small">
+                <c-stats
+                    lwc:if={hasCalloutStats}
+                    label="Callout Stats"
+                    icon-name="standard:data_integration_hub"
+                    value={calloutStats}
+                ></c-stats>
+                <div class="slds-m-vertical_medium">
+                    <c-error-alert value={error}></c-error-alert>
+                </div>
+                <lightning-layout lwc:if={hasError} horizontal-align="center" class="slds-m-vertical_small">
+                    <lightning-layout-item flexibility="no-grow" class="slds-text-align_center">
+                        <p>Add Authentication Setting for External System for <i>{selectedNamedCredential.MasterLabel}</i></p>
+                        <lightning-button
+                            label="Authenticate"
+                            variant="base"
+                            onclick={handleRedirectToAuthPage}
+                        ></lightning-button>
+                    </lightning-layout-item>
+                </lightning-layout>
+            </lightning-layout-item>
+        </lightning-layout>
+    </lightning-card>
+</template>

--- a/src/minlopro/main/lwc/perUserNamedCredentialTab/perUserNamedCredentialTab.js
+++ b/src/minlopro/main/lwc/perUserNamedCredentialTab/perUserNamedCredentialTab.js
@@ -1,0 +1,100 @@
+import { LightningElement, track, wire } from 'lwc';
+import { NavigationMixin } from 'lightning/navigation';
+import $Toastify from 'c/toastify';
+import { cloneObject, isEmpty, isNotEmpty } from 'c/utilities';
+
+// Apex Controller Methods;
+import getNamedCredentialsApex from '@salesforce/apex/PerUserNamedCredentialController.getNamedCredentials';
+import getDataUserAuthUrlApex from '@salesforce/apex/PerUserNamedCredentialController.getDataUserAuthUrl';
+import invokeApex from '@salesforce/apex/PerUserNamedCredentialController.invoke';
+
+export default class PerUserNamedCredentialTab extends NavigationMixin(LightningElement) {
+    @track selectedValue = 'SalesforceRestApi';
+    @track loading = true;
+    @track calloutStats = null;
+    @track error = null;
+
+    get namedCredentialOptions() {
+        return this.namedCredentials.map(({ MasterLabel, DeveloperName, PrincipalType }) => ({
+            label: `${MasterLabel} (${PrincipalType})`,
+            value: DeveloperName
+        }));
+    }
+
+    get namedCredentials() {
+        if (isEmpty(this.wiredNamedCredentials.data)) {
+            return [];
+        }
+        return cloneObject(this.wiredNamedCredentials.data);
+    }
+
+    get selectedNamedCredential() {
+        return this.namedCredentials.find(({ DeveloperName }) => DeveloperName === this.selectedValue);
+    }
+
+    get doDisableBtn() {
+        return this.loading || isEmpty(this.selectedValue);
+    }
+
+    get hasCalloutStats() {
+        return isNotEmpty(this.calloutStats);
+    }
+
+    get hasError() {
+        return isNotEmpty(this.error);
+    }
+
+    @wire(getNamedCredentialsApex)
+    wiredNamedCredentials = {};
+
+    connectedCallback() {
+        this.loading = false;
+    }
+
+    handleSelect(event) {
+        const { value } = event.detail;
+        this.selectedValue = value;
+    }
+
+    async handleInvokeCallout() {
+        this.loading = true;
+        this.calloutStats = null;
+        this.error = null;
+        try {
+            const result = await invokeApex({ namedCredentialApiName: this.selectedValue });
+            this.calloutStats = cloneObject(result);
+            if (this.calloutStats.success) {
+                $Toastify.success({ message: 'HTTP callout succeeded!' });
+            } else {
+                $Toastify.warning({ message: 'HTTP callout failed! Check stats for details.' });
+                this.error = { message: 'Unsuccessful HTTP response code received' };
+            }
+        } catch (error) {
+            this.error = error;
+            $Toastify.error({ message: 'HTTP callout failed! Check stats for details.' });
+        } finally {
+            this.loading = false;
+        }
+    }
+
+    async handleRedirectToAuthPage() {
+        // this[NavigationMixin.Navigate](
+        //     {
+        //         type: 'standard__webPage',
+        //         attributes: {
+        //             url: 'https://@SF_SITE_DOMAIN_NAME.my.salesforce-setup.com/lightning/settings/personal/ExternalObjectUserSettings/home'
+        //         }
+        //     },
+        //     false
+        // );
+        this.loading = true;
+        try {
+            const url = await getDataUserAuthUrlApex({ namedCredentialApiName: this.selectedValue });
+            window.open(url, 'Enter Login Details', 'width=900,height=600');
+        } catch (error) {
+            this.error = error;
+        } finally {
+            this.loading = false;
+        }
+    }
+}

--- a/src/minlopro/main/lwc/perUserNamedCredentialTab/perUserNamedCredentialTab.js-meta.xml
+++ b/src/minlopro/main/lwc/perUserNamedCredentialTab/perUserNamedCredentialTab.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <description>Per User Named Credential Tab</description>
+    <isExposed>false</isExposed>
+    <masterLabel>Per User Named Credential Tab</masterLabel>
+</LightningComponentBundle>

--- a/src/minlopro/main/lwc/workspace/workspace.html
+++ b/src/minlopro/main/lwc/workspace/workspace.html
@@ -62,6 +62,9 @@
                 <template lwc:elseif={isOcrDemo}>
                     <c-ocr-demo></c-ocr-demo>
                 </template>
+                <template lwc:elseif={isPerUserNamedCredential}>
+                    <c-per-user-named-credential-tab></c-per-user-named-credential-tab>
+                </template>
                 <template lwc:else>
                     <c-error-alert value="Unknown Demo LWC Mapping!"></c-error-alert>
                 </template>

--- a/src/minlopro/main/lwc/workspace/workspace.js
+++ b/src/minlopro/main/lwc/workspace/workspace.js
@@ -15,6 +15,7 @@ const $KeysetPagination = 'keysetPagination';
 const $DragAndDrop = 'Drag&Drop';
 const $PdfLibDemo = 'PDF-Lib';
 const $OcrDemo = 'tesseract-js-ocr';
+const $PerUserNamedCredentialDemo = 'perUserNamedCredential';
 
 // Custom Permissions;
 import IS_FILES_MANAGER from '@salesforce/customPermission/IsFilesManager';
@@ -39,7 +40,13 @@ export default class Workspace extends LightningElement {
             { label: 'Keyset Pagination', name: $KeysetPagination, iconName: 'utility:breadcrumbs', visible: true },
             { label: 'Drag & Drop', name: $DragAndDrop, iconName: 'utility:drag', visible: true },
             { label: 'PDF-Lib Demo', name: $PdfLibDemo, iconName: 'utility:pdf_ext', visible: true },
-            { label: 'TesseractJS-OCR', name: $OcrDemo, iconName: 'utility:scan', visible: IS_OCR_USER }
+            { label: 'TesseractJS-OCR', name: $OcrDemo, iconName: 'utility:scan', visible: IS_OCR_USER },
+            {
+                label: 'Per-User Named Credential Demo',
+                name: $PerUserNamedCredentialDemo,
+                iconName: 'utility:integration',
+                visible: true
+            }
         ]
             .map((tabInfo) => {
                 tabInfo.label = this.doCollapseTabs ? '' : tabInfo.label;
@@ -99,6 +106,10 @@ export default class Workspace extends LightningElement {
 
     get isOcrDemo() {
         return this.selectedTabName === $OcrDemo;
+    }
+
+    get isPerUserNamedCredential() {
+        return this.selectedTabName === $PerUserNamedCredentialDemo;
     }
 
     get lc_selectedTabName() {

--- a/src/minlopro/main/namedCredentials/SalesforceRestApiPerUser.namedCredential-meta.xml
+++ b/src/minlopro/main/namedCredentials/SalesforceRestApiPerUser.namedCredential-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<NamedCredential xmlns="http://soap.sforce.com/2006/04/metadata">
+    <allowMergeFieldsInBody>false</allowMergeFieldsInBody>
+    <allowMergeFieldsInHeader>false</allowMergeFieldsInHeader>
+    <authProvider>Loopback_CCF</authProvider>
+    <calloutStatus>Enabled</calloutStatus>
+    <endpoint>@SF_INSTANCE_URL</endpoint>
+    <generateAuthorizationHeader>true</generateAuthorizationHeader>
+    <label>Salesforce REST API (Per-User)</label>
+    <principalType>PerUser</principalType>
+    <protocol>Oauth</protocol>
+</NamedCredential>

--- a/src/minlopro/main/permissionsets/Minlopro_CustomAuthProviderAndNC.permissionset-meta.xml
+++ b/src/minlopro/main/permissionsets/Minlopro_CustomAuthProviderAndNC.permissionset-meta.xml
@@ -5,7 +5,15 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>OAuthJwtAuthProviderPlugin</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>OAuthWebServerWithPkceAuthProviderPlugin</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>PerUserNamedCredentialController</apexClass>
         <enabled>true</enabled>
     </classAccesses>
     <externalCredentialPrincipalAccesses>
@@ -13,7 +21,7 @@
         <externalCredentialPrincipal>MinloproSalesforceLoopback-Default</externalCredentialPrincipal>
     </externalCredentialPrincipalAccesses>
     <hasActivationRequired>false</hasActivationRequired>
-    <label>Minlopro - Custom Auth.Providers And Named Credentials</label>
+    <label>Minlopro - Custom Auth. Providers And Named Credentials</label>
     <objectPermissions>
         <allowCreate>false</allowCreate>
         <allowDelete>false</allowDelete>


### PR DESCRIPTION
## Details

**Named Principal** (aka `NamedUser`) named credentials are applied org-wide regardless of running user permissions:

<img width="1771" alt="image" src="https://github.com/user-attachments/assets/2608e269-219a-4f99-bddb-c73b19850713" />

**Per User** named credentials are user-based, and MUST be authenticated on a user basis:

| User Settings Page | Success |
| ----- | ----- |
| <img width="1771" alt="image" src="https://github.com/user-attachments/assets/134cc76a-5cdb-40c4-a4f7-dcf43b00aec8" /> | <img width="1775" alt="image" src="https://github.com/user-attachments/assets/598a2912-84a7-46ce-b435-bc3418d15a67" /> |

Otherwise, the Apex transaction fails when a non-authenticated Salesforce user attempts to perform HTTP callout:

| User Settings Page | Failure |
| ----- | ----- |
| <img width="1776" alt="image" src="https://github.com/user-attachments/assets/069b0938-52db-4465-b7e8-f845bdeb16a4" /> | <img width="1780" alt="image" src="https://github.com/user-attachments/assets/13ba0121-cbd5-4239-b347-f9dc96869df5" /> |

Eventually, the full list of authenticated users can be found on Named Credential details page:

<img width="1065" alt="image" src="https://github.com/user-attachments/assets/8b73d418-f9b4-44b8-b943-01b8451a18cd" />