### PR TITLE
Minlopro: Detecting duplicate PersonAccounts & Merging them

### DIFF
--- a/CODECONVENTIONS.md
+++ b/CODECONVENTIONS.md
@@ -1,19 +1,19 @@
 # Code Conventions
 
--   [Introduction](#introduction)
--   [General Best Practices](#general-best-practices)
--   [Code Conventions](#code-conventions)
-    -   [Apex Classes](#apex-classes)
-        -   [Naming Conventions](#naming-conventions)
-        -   [Critical Coding Standards](#critical-coding-standards)
-        -   [Class Design](#class-design)
-        -   [Unit Tests](#unit-tests)
-    -   [LWC (Lightning Web Components)](#lwc-lightning-web-components)
-        -   [Naming Conventions](#naming-conventions-1)
-        -   [Critical Coding Standards](#critical-coding-standards-1)
-    -   [Aura Components](#aura-components)
-        -   [Naming Conventions](#naming-conventions-2)
-        -   [Critical Coding Standards](#critical-coding-standards-2)
+- [Introduction](#introduction)
+- [General Best Practices](#general-best-practices)
+- [Code Conventions](#code-conventions)
+    - [Apex Classes](#apex-classes)
+        - [Naming Conventions](#naming-conventions)
+        - [Critical Coding Standards](#critical-coding-standards)
+        - [Class Design](#class-design)
+        - [Unit Tests](#unit-tests)
+    - [LWC (Lightning Web Components)](#lwc-lightning-web-components)
+        - [Naming Conventions](#naming-conventions-1)
+        - [Critical Coding Standards](#critical-coding-standards-1)
+    - [Aura Components](#aura-components)
+        - [Naming Conventions](#naming-conventions-2)
+        - [Critical Coding Standards](#critical-coding-standards-2)
 
 ## Introduction
 
@@ -23,11 +23,11 @@ This guide serves as a comprehensive reference for Salesforce developers, coveri
 
 ## General Best Practices
 
--   Every declarative metadata component (flow, custom object, custom field etc.) must have clear & meaningful description provided.
--   Configure/wWrite polite, user-friendly error messages.
-    -   Example: Prefer “Please provide a value for the Status field” over “Missing required field.”
--   Avoid hardcoding sensitive data like IDs or credentials.
--   Design your logic to handle large data sets and avoid hitting Salesforce's governor limits.
+- Every declarative metadata component (flow, custom object, custom field etc.) must have clear & meaningful description provided.
+- Configure/wWrite polite, user-friendly error messages.
+    - Example: Prefer “Please provide a value for the Status field” over “Missing required field.”
+- Avoid hardcoding sensitive data like IDs or credentials.
+- Design your logic to handle large data sets and avoid hitting Salesforce's governor limits.
 
 ---
 
@@ -70,9 +70,9 @@ This guide serves as a comprehensive reference for Salesforce developers, coveri
 
 Follow the separation of concerns (SoC) principle:
 
--   **Controller Classes**: Handle UI-related logic.
--   **Service Classes**: Contain business logic.
--   **Selector Classes**: Perform SOQL queries.
+- **Controller Classes**: Handle UI-related logic.
+- **Service Classes**: Contain business logic.
+- **Selector Classes**: Perform SOQL queries.
 
 Example Class Structure:
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 <span>[![Release](https://github.com/awesomeandrey/minlopro-dx/actions/workflows/release_workflow.yml/badge.svg?branch=main)](https://github.com/awesomeandrey/minlopro-dx/actions/workflows/release_workflow.yml)</span>
 <span>[![Reset Destructive Manifests](https://github.com/awesomeandrey/minlopro-dx/actions/workflows/reset_destructive_manifests.yml/badge.svg)](https://github.com/awesomeandrey/minlopro-dx/actions/workflows/reset_destructive_manifests.yml)</span>
 
--   [About](#about)
--   [Prerequisites](#prerequisites)
--   [Branches](#branches)
-    -   [Release Branch Preparation](#release-branch-preparation)
--   [Managing Environment Variables](#managing-environment-variables)
--   [Scripts in `package.json`](#scripts-in-packagejson)
-    -   [Useful Commands](#useful-commands)
+- [About](#about)
+- [Prerequisites](#prerequisites)
+- [Branches](#branches)
+    - [Release Branch Preparation](#release-branch-preparation)
+- [Managing Environment Variables](#managing-environment-variables)
+- [Scripts in `package.json`](#scripts-in-packagejson)
+    - [Useful Commands](#useful-commands)
 
 ## About
 

--- a/manifests/destructiveChangesPost.xml
+++ b/manifests/destructiveChangesPost.xml
@@ -1,8 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
-    <types>
-        <members>Contact.MatchByNameOrPhone</members>
-        <name>MatchingRule</name>
-    </types>
     <version>61.0</version>
 </Package>

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,8 @@
                 "jest-unit": "^0.0.2",
                 "jsonwebtoken": "^9.0.2",
                 "pmd-bin": "^1.37.0",
-                "prettier": "^3.1.1",
-                "prettier-plugin-apex": "^2.0.1",
+                "prettier": "^3.5.1",
+                "prettier-plugin-apex": "^2.2.4",
                 "prettier-plugin-sql": "^0.18.1",
                 "xml2js": "^0.6.2"
             },
@@ -906,13 +906,15 @@
             "version": "9.3.0",
             "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
             "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
-            "dev": true
+            "dev": true,
+            "license": "BSD-3-Clause"
         },
         "node_modules/@hapi/topo": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
             "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "@hapi/hoek": "^9.0.0"
             }
@@ -1477,6 +1479,62 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@prettier-apex/apex-ast-serializer-darwin-arm64": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/@prettier-apex/apex-ast-serializer-darwin-arm64/-/apex-ast-serializer-darwin-arm64-2.2.4.tgz",
+            "integrity": "sha512-18MuJS1iPTgEHS2gPS1b8MfHkj2cpO5IK+ojOs3v+jh0JC5lzumO1p/CjUXb2Bd5HopOC42dFIb1HXaax5JgGQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@prettier-apex/apex-ast-serializer-darwin-x64": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/@prettier-apex/apex-ast-serializer-darwin-x64/-/apex-ast-serializer-darwin-x64-2.2.4.tgz",
+            "integrity": "sha512-7ieK8FP7jGLaNDtOj3dAwP+8/Cu+0DM/HBn8ntR6fmMaKt6yr5rbq1BhIgdMCjbVTph0CUdE97Uli+AQEQvxeg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@prettier-apex/apex-ast-serializer-linux-x64": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/@prettier-apex/apex-ast-serializer-linux-x64/-/apex-ast-serializer-linux-x64-2.2.4.tgz",
+            "integrity": "sha512-/i+PyD5/ohorLJ+iz2XzR5E4htfJ/xmE37dlvvth2WxEN4m0YNOjMRDI2sE+1HjPTZdG+m+cJuqq1UYZWmLFTg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@prettier-apex/apex-ast-serializer-win32-x64": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/@prettier-apex/apex-ast-serializer-win32-x64/-/apex-ast-serializer-win32-x64-2.2.4.tgz",
+            "integrity": "sha512-SbT9ufY8OP976Owbefr/t8jPqZM51ps/gOavWjA/cu3+thOD4r50hMJ+Ke7NgTSwh11q2rPkadicCk/x2Y9HeA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
         "node_modules/@prettier/plugin-xml": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-2.2.0.tgz",
@@ -1532,10 +1590,11 @@
             }
         },
         "node_modules/@sideway/address": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
-            "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+            "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "@hapi/hoek": "^9.0.0"
             }
@@ -1544,13 +1603,15 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
             "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
-            "dev": true
+            "dev": true,
+            "license": "BSD-3-Clause"
         },
         "node_modules/@sideway/pinpoint": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
             "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
-            "dev": true
+            "dev": true,
+            "license": "BSD-3-Clause"
         },
         "node_modules/@sinclair/typebox": {
             "version": "0.27.8",
@@ -1893,6 +1954,7 @@
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
             "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.0",
@@ -1900,13 +1962,15 @@
             }
         },
         "node_modules/axios/node_modules/form-data": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+            "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
                 "mime-types": "^2.1.12"
             },
             "engines": {
@@ -3072,14 +3136,16 @@
             }
         },
         "node_modules/es-set-tostringtag": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.2.tgz",
-            "integrity": "sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "get-intrinsic": "^1.2.2",
-                "has-tostringtag": "^1.0.0",
-                "hasown": "^2.0.0"
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -3326,6 +3392,7 @@
                     "url": "https://github.com/sponsors/RubenVerborgh"
                 }
             ],
+            "license": "MIT",
             "engines": {
                 "node": ">=4.0"
             },
@@ -3677,12 +3744,13 @@
             }
         },
         "node_modules/has-tostringtag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-            "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "has-symbols": "^1.0.2"
+                "has-symbols": "^1.0.3"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -5233,14 +5301,15 @@
             }
         },
         "node_modules/joi": {
-            "version": "17.11.0",
-            "resolved": "https://registry.npmjs.org/joi/-/joi-17.11.0.tgz",
-            "integrity": "sha512-NgB+lZLNoqISVy1rZocE9PZI36bL/77ie924Ri43yEvi9GUUMPeyVIr8KdFTMUlby1p0PBYMk9spIxEUQYqrJQ==",
+            "version": "17.13.3",
+            "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+            "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "@hapi/hoek": "^9.0.0",
-                "@hapi/topo": "^5.0.0",
-                "@sideway/address": "^4.1.3",
+                "@hapi/hoek": "^9.3.0",
+                "@hapi/topo": "^5.1.0",
+                "@sideway/address": "^4.1.5",
                 "@sideway/formula": "^3.0.1",
                 "@sideway/pinpoint": "^2.0.0"
             }
@@ -6160,10 +6229,11 @@
             "dev": true
         },
         "node_modules/prettier": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
-            "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.1.tgz",
+            "integrity": "sha512-hPpFQvHwL3Qv5AdRvBFMhnKo4tYxp0ReXiPn2bxkiohEX6mBeBwEpBSQTkD458RaaDKQMYSp4hX4UtfUTA5wDw==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -6175,13 +6245,14 @@
             }
         },
         "node_modules/prettier-plugin-apex": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-apex/-/prettier-plugin-apex-2.0.1.tgz",
-            "integrity": "sha512-S64zate3iXPKiBKHf27YRapIAPPd1wQ/u5IOcWwSHNgoJv15I14HhoUB/WOKXtxFb0ZH5MO1nF8gRGWXLajwlA==",
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-apex/-/prettier-plugin-apex-2.2.4.tgz",
+            "integrity": "sha512-/mqsKuQ1TbGzav+WKi0EsOl+Ttappwh69KM5M04vTQXznk70jrNmEGNaCK3KvvVDMDwLSYCg8bkc9HsumWVfqg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "jest-docblock": "^29.0.0",
-                "wait-on": "^7.0.0"
+                "wait-on": "^8.0.0"
             },
             "bin": {
                 "apex-ast-serializer": "vendor/apex-ast-serializer/bin/apex-ast-serializer",
@@ -6189,8 +6260,11 @@
                 "start-apex-server": "dist/bin/start-apex-server.js",
                 "stop-apex-server": "dist/bin/stop-apex-server.js"
             },
-            "engines": {
-                "node": ">= 18.11.0"
+            "optionalDependencies": {
+                "@prettier-apex/apex-ast-serializer-darwin-arm64": "2.2.4",
+                "@prettier-apex/apex-ast-serializer-darwin-x64": "2.2.4",
+                "@prettier-apex/apex-ast-serializer-linux-x64": "2.2.4",
+                "@prettier-apex/apex-ast-serializer-win32-x64": "2.2.4"
             },
             "peerDependencies": {
                 "prettier": "^3.0.0"
@@ -6272,7 +6346,8 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
             "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/psl": {
             "version": "1.9.0",
@@ -6512,6 +6587,7 @@
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
             "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.1.0"
             }
@@ -7366,13 +7442,14 @@
             }
         },
         "node_modules/wait-on": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
-            "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-8.0.2.tgz",
+            "integrity": "sha512-qHlU6AawrgAIHlueGQHQ+ETcPLAauXbnoTKl3RKq20W0T8x0DKVAo5xWIYjHSyvHxQlcYbFdR0jp4T9bDVITFA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "axios": "^1.6.1",
-                "joi": "^17.11.0",
+                "axios": "^1.7.9",
+                "joi": "^17.13.3",
                 "lodash": "^4.17.21",
                 "minimist": "^1.2.8",
                 "rxjs": "^7.8.1"

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
         "jest-unit": "^0.0.2",
         "jsonwebtoken": "^9.0.2",
         "pmd-bin": "^1.37.0",
-        "prettier": "^3.1.1",
-        "prettier-plugin-apex": "^2.0.1",
+        "prettier": "^3.5.1",
+        "prettier-plugin-apex": "^2.2.4",
         "prettier-plugin-sql": "^0.18.1",
         "xml2js": "^0.6.2"
     }

--- a/scripts/automations/create_crma_scratch_org.sh
+++ b/scripts/automations/create_crma_scratch_org.sh
@@ -55,7 +55,7 @@ echo "$SCRATCH_ORG_ALIAS" | bash ./scripts/crm-analytics/deploy.sh
 echo "$SCRATCH_ORG_ALIAS" | bash ./scripts/crm-analytics/util/set_up_admin_user.sh
 
 # Deactivate all duplicate rules
-echo "$SCRATCH_ORG_ALIAS" | bash ./scripts/util/deactivate_all_duplicate_rules.sh
+echo "$SCRATCH_ORG_ALIAS" | bash ./scripts/util/duplicates-mgmt/deactivate_all_duplicate_rules.sh
 
 # Import sample data
 echo "$SCRATCH_ORG_ALIAS" | bash ./scripts/util/data-seeding/import_sample_data.sh

--- a/scripts/deploy/post/custom/display_records_count.sh
+++ b/scripts/deploy/post/custom/display_records_count.sh
@@ -14,6 +14,8 @@ sf org list sobject record-counts \
   --sobject Account \
   --sobject Contact \
   --sobject CurrencyType \
+  --sobject DuplicateRecordSet \
+  --sobject DuplicateRecordItem \
   --sobject EmailTemplate \
   --sobject Lead \
   --sobject LogEntry__c \

--- a/scripts/util/data-seeding/delete_all_object_records.sh
+++ b/scripts/util/data-seeding/delete_all_object_records.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# How to use:
+# - bash ./scripts/util/data-seeding/delete_all_object_records.sh
+# - bash ./scripts/util/data-seeding/delete_all_object_records.sh "$TARGET_ORG_ALIAS" "OBJECT_API_NAME"
+
+# Enable errexit option to exit on command failure
+set -e
+
+TARGET_ORG_ALIAS=$1
+OBJECT_API_NAME=$2
+
+if [ -z "$TARGET_ORG_ALIAS" ] || [ -z "$OBJECT_API_NAME" ]; then
+  read -r -p "🔶 Enter Org Alias: " TARGET_ORG_ALIAS
+  read -r -p "🔶 Enter Object API Name: " OBJECT_API_NAME
+fi
+
+echo "🔵 Deleting all [$OBJECT_API_NAME] records in [$TARGET_ORG_ALIAS] org..."
+
+mkdir -p "build"
+duplicateRecordSetsCsv="build/${TARGET_ORG_ALIAS}-${OBJECT_API_NAME}.csv"
+
+# Bulk export DRSs records
+sf data export bulk \
+  --target-org "$TARGET_ORG_ALIAS" \
+  --query "SELECT Id FROM DuplicateRecordSet" \
+  --output-file "$duplicateRecordSetsCsv" \
+  --result-format "csv" \
+  --wait 20
+
+if [[ $(wc -w < "$duplicateRecordSetsCsv") -lt 5 ]]; then
+    echo "No data to delete."
+    exit 0
+fi
+
+# Bulk delete DRSs records
+sf data delete bulk \
+  --target-org "$TARGET_ORG_ALIAS" \
+  --sobject "DuplicateRecordSet" \
+  --file "$duplicateRecordSetsCsv" \
+  --wait 20 \
+  

--- a/scripts/util/duplicates-mgmt/deactivate_all_duplicate_rules.sh
+++ b/scripts/util/duplicates-mgmt/deactivate_all_duplicate_rules.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 
 # How to use:
-# - bash ./scripts/util/deactivate_all_duplicate_rules.sh
-# - echo $ORG_ALIAS | bash ./scripts/util/deactivate_all_duplicate_rules.sh
+# - bash ./scripts/util/duplicates-mgmt/deactivate_all_duplicate_rules.sh
+# - echo $TARGET_ORG_ALIAS | bash ./scripts/util/duplicates-mgmt/deactivate_all_duplicate_rules.sh
 
 # Enable errexit option to exit on command failure
 set -e
 
 # Capture Org alias
-read -r -p "🔶 Enter Org Alias: " ORG_ALIAS
+read -r -p "🔶 Enter Org Alias: " TARGET_ORG_ALIAS
 
-echo "🔵 Deactivating all duplicate rules in [$ORG_ALIAS] org..."
+echo "🔵 Deactivating all duplicate rules in [$TARGET_ORG_ALIAS] org..."
 
 # Get project API version
 PROJECT_API_VERSION=$(bash ./scripts/util/get_project_api_version.sh)
@@ -36,9 +36,9 @@ cat <<EOL > "$MANIFEST_FILE"
 EOL
 
 # Retrieve Duplicate Rules metadata from the Salesforce Org
-echo "Retrieving duplicate rules metadata from [$ORG_ALIAS] org..."
+echo "Retrieving duplicate rules metadata from [$TARGET_ORG_ALIAS] org..."
 sf project retrieve start \
- --target-org "$ORG_ALIAS" \
+ --target-org "$TARGET_ORG_ALIAS" \
  --manifest "$MANIFEST_FILE" \
  --target-metadata-dir "$workingDir" \
  --unzip \
@@ -58,9 +58,9 @@ for file in "$workingDir/package/unpackaged/duplicateRules"/*; do
 done
 
 # Deploying deactivated Duplicate Rules back to the Salesforce Org
-echo "Deploying deactivated duplicate rules back to the [$ORG_ALIAS] org..."
+echo "Deploying deactivated duplicate rules back to the [$TARGET_ORG_ALIAS] org..."
 sf project deploy start \
-   --target-org "$ORG_ALIAS" \
+   --target-org "$TARGET_ORG_ALIAS" \
    --metadata-dir "./$workingDir/package/unpackaged" \
    --verbose \
    --ignore-warnings \

--- a/scripts/util/migrate-orgs-auth/export_orgs.sh
+++ b/scripts/util/migrate-orgs-auth/export_orgs.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
+
 # export_orgs.sh: Exports a separate JSON auth file for each authenticated org.
+# Inspired by https://medium.com/@sgorla/effortlessly-transfer-salesforce-org-authentication-between-machines-using-shell-scripts-074c4fc12622
+
+# How to use:
+# - bash scripts/util/migrate-orgs-auth/export_orgs.sh
 
 # Directory to store exported files
 EXPORT_DIR="org_auth_files"

--- a/scripts/util/migrate-orgs-auth/import_orgs_with_alias.sh
+++ b/scripts/util/migrate-orgs-auth/import_orgs_with_alias.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
+
 # import_orgs_with_alias.sh: Authenticates each org using its corresponding JSON file and assigns aliases.
+# Inspired by https://medium.com/@sgorla/effortlessly-transfer-salesforce-org-authentication-between-machines-using-shell-scripts-074c4fc12622
+
+# How to use:
+# - bash scripts/util/migrate-orgs-auth/export_orgs.sh
 
 # Directory containing JSON auth files
 IMPORT_DIR="org_auth_files"

--- a/src/minlopro-core/README.md
+++ b/src/minlopro-core/README.md
@@ -2,21 +2,21 @@
 
 ## Re-usable Lightning Web Components
 
--   `bridge.js` - used for communication between components (based off of LMS)
--   `c-combobox` - custom LWC that extends base `lightning-combobox` LWC
--   `c-datatable` - extension of base `lightning-datatable` LWC that supports editable lookups & picklists
--   `c-stencil-skeleton` - UI LWC that improves UX while component is loading
--   `toastify.js` - utility module that facades API around toast notifications
--   `utilities.js` - boilerplate JS functions
+- `bridge.js` - used for communication between components (based off of LMS)
+- `c-combobox` - custom LWC that extends base `lightning-combobox` LWC
+- `c-datatable` - extension of base `lightning-datatable` LWC that supports editable lookups & picklists
+- `c-stencil-skeleton` - UI LWC that improves UX while component is loading
+- `toastify.js` - utility module that facades API around toast notifications
+- `utilities.js` - boilerplate JS functions
 
 [Check out `c-datatable` with Custom Data Types](https://youtu.be/DvqtHMrvp8k)
 
 Features:
 
--   CDT for _Lookup_
--   CDT for _Picklist (Single/Multi)_
--   CDT for _Dependent Picklist (Single/Multi)_
--   CDT for _Custom Combobox (with icons & 'fixed' mode)_
+- CDT for _Lookup_
+- CDT for _Picklist (Single/Multi)_
+- CDT for _Dependent Picklist (Single/Multi)_
+- CDT for _Custom Combobox (with icons & 'fixed' mode)_
 
 | Datatable                                                                                                                        | Lookup CDT                                                               | Picklist CDT                                                               |
 | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
@@ -28,8 +28,8 @@ Open-source framework for Salesforce development.
 
 Sources:
 
--   https://github.com/apex-enterprise-patterns/fflib-apex-common
--   https://github.com/apex-enterprise-patterns/fflib-apex-mocks
+- https://github.com/apex-enterprise-patterns/fflib-apex-common
+- https://github.com/apex-enterprise-patterns/fflib-apex-mocks
 
 ## Logger
 

--- a/src/minlopro-core/main/classes/trigger-handler-core/TriggerDispatcher.cls
+++ b/src/minlopro-core/main/classes/trigger-handler-core/TriggerDispatcher.cls
@@ -1,9 +1,9 @@
 public with sharing class TriggerDispatcher {
     // Static properties;
-    private static final Map<SObjectType, Set<TriggerHandler>> activateHandlersByObjectTypeMap {
+    private static final Map<SObjectType, Set<TriggerHandler>> activeHandlersByObjectTypeMap {
         get {
-            if (activateHandlersByObjectTypeMap == null) {
-                activateHandlersByObjectTypeMap = new Map<SObjectType, Set<TriggerHandler>>();
+            if (activeHandlersByObjectTypeMap == null) {
+                activeHandlersByObjectTypeMap = new Map<SObjectType, Set<TriggerHandler>>();
                 for (TriggerHandler__mdt handlerCmt : [
                     SELECT Id, TargetObject__c, ApexClassName__c, Order__c, Active__c
                     FROM TriggerHandler__mdt
@@ -11,13 +11,13 @@ public with sharing class TriggerDispatcher {
                     ORDER BY Order__c ASC
                 ]) {
                     TriggerHandler handlerItem = new TriggerHandler(handlerCmt);
-                    if (!activateHandlersByObjectTypeMap.containsKey(handlerItem.objectType)) {
-                        activateHandlersByObjectTypeMap.put(handlerItem.objectType, new Set<TriggerHandler>());
+                    if (!activeHandlersByObjectTypeMap.containsKey(handlerItem.objectType)) {
+                        activeHandlersByObjectTypeMap.put(handlerItem.objectType, new Set<TriggerHandler>());
                     }
-                    activateHandlersByObjectTypeMap.get(handlerItem.objectType).add(handlerItem);
+                    activeHandlersByObjectTypeMap.get(handlerItem.objectType).add(handlerItem);
                 }
             }
-            return activateHandlersByObjectTypeMap;
+            return activeHandlersByObjectTypeMap;
         }
         set;
     }
@@ -124,8 +124,8 @@ public with sharing class TriggerDispatcher {
             } else {
                 return new Set<TriggerHandler>();
             }
-        } else if (activateHandlersByObjectTypeMap.containsKey(this.currentObjectType)) {
-            return activateHandlersByObjectTypeMap.get(this.currentObjectType);
+        } else if (activeHandlersByObjectTypeMap.containsKey(this.currentObjectType)) {
+            return activeHandlersByObjectTypeMap.get(this.currentObjectType);
         } else {
             return new Set<TriggerHandler>();
         }

--- a/src/minlopro-digex-messaging/README.md
+++ b/src/minlopro-digex-messaging/README.md
@@ -2,8 +2,8 @@
 
 Originally inspired by the following articles:
 
--   https://medium.com/@rjallu01/salesforce-how-to-setup-messaging-for-in-app-and-web-user-verification-for-communities-eb77ebd96b85
--   https://medium.com/@rjallu01/salesforce-messaging-miaw-how-to-setup-pre-chat-form-for-communities-6886ec58d7c9
+- https://medium.com/@rjallu01/salesforce-how-to-setup-messaging-for-in-app-and-web-user-verification-for-communities-eb77ebd96b85
+- https://medium.com/@rjallu01/salesforce-messaging-miaw-how-to-setup-pre-chat-form-for-communities-6886ec58d7c9
 
 Functionality Preview:
 
@@ -20,8 +20,8 @@ Functionality Preview:
 
 The following files leverage SFDX Replacements in scope of deployments:
 
--   [ESW_Minlopro_DigExMessaging Site](src/minlopro-digex-messaging/main/sites/ESW_Minlopro_DigExMessaging.site-meta.xml)
--   [DigEx Home Page](src/minlopro-digex/main/experiences/DigEx1/views/home.json)
+- [ESW_Minlopro_DigExMessaging Site](src/minlopro-digex-messaging/main/sites/ESW_Minlopro_DigExMessaging.site-meta.xml)
+- [DigEx Home Page](src/minlopro-digex/main/experiences/DigEx1/views/home.json)
 
 ### Troubleshooting
 

--- a/src/minlopro-digex/main/lwc/digExWebToLeadForm/README.md
+++ b/src/minlopro-digex/main/lwc/digExWebToLeadForm/README.md
@@ -54,15 +54,15 @@ There are rules to the HTTP request payload to follow:
 
 1. the payload must contain Salesforce organization ID parameter (see `oid` form parameter)
 
--   this parameter is used to route the Lead to the right Salesforce organization
--   `oid` accepts either 15 or 18 digit Salesforce instance ID (both work, but the latter one is preferred)
+- this parameter is used to route the Lead to the right Salesforce organization
+- `oid` accepts either 15 or 18 digit Salesforce instance ID (both work, but the latter one is preferred)
 
 2. form parameter names must correspond to valid custom/standard fields on **Lead** object in target Salesforce organization:
 
--   if the form contains a parameter that does not match Lead standard/custom field then the value of this parameter will be lost
--   the form parameters can be mapped by _Salesforce Field API Name_ and/or by its _Salesforce Field ID_:
-    -   `<input name="SomeCustomField__c" ...` – is a valid approach to map form parameter by Salesforce field API name
-    -   `<input name="00N34000005KYzq" ...` – is a valid approach to map form parameter by Salesforce field ID (i.e. `00N34000005KYzq` corresponds to `SomeCustomField__c` field ID in Salesforce)
+- if the form contains a parameter that does not match Lead standard/custom field then the value of this parameter will be lost
+- the form parameters can be mapped by _Salesforce Field API Name_ and/or by its _Salesforce Field ID_:
+    - `<input name="SomeCustomField__c" ...` – is a valid approach to map form parameter by Salesforce field API name
+    - `<input name="00N34000005KYzq" ...` – is a valid approach to map form parameter by Salesforce field ID (i.e. `00N34000005KYzq` corresponds to `SomeCustomField__c` field ID in Salesforce)
 
 **Salesforce Field IDs are preserved between Salesforce instances**. Therefore the same field IDs can be defined as form parameter names in counterpart environments (dev, test & prod envs).
 

--- a/src/minlopro-dlrs/README.md
+++ b/src/minlopro-dlrs/README.md
@@ -9,8 +9,8 @@ Package ID: `04t5p000001E8vdAAC`.
 Here is sophisticated guide of DLRS package functionality - https://sfdo-community-sprints.github.io/DLRS-Documentation.
 Make sure to assign the following permission sets to Admun user(s):
 
--   `dlrs__LookupRollupSummariesFull`
--   `dlrs__LookupRollupSummariesReadOnly`
+- `dlrs__LookupRollupSummariesFull`
+- `dlrs__LookupRollupSummariesReadOnly`
 
 ## Trigger Handler Framework Compatibility
 

--- a/src/minlopro/main/classes/TestDataFactory.cls
+++ b/src/minlopro/main/classes/TestDataFactory.cls
@@ -70,7 +70,8 @@ public class TestDataFactory {
 
     public static User createRegularUser() {
         Profile minloproUserProfile = TestDataFactory.selectMinloproUserProfile();
-        User regularUser = TestDataFactory.createUser('Mike', 'Green', minloproUserProfile.Id);
+        String randomUsername = generateRandomString(8);
+        User regularUser = TestDataFactory.createUser('Mike', 'Green-' + randomUsername, minloproUserProfile.Id);
         // Assign Role;
         regularUser.UserRoleId = null;
         // Create user;

--- a/src/minlopro/main/objects/Account/listViews/TodayAccounts.listView-meta.xml
+++ b/src/minlopro/main/objects/Account/listViews/TodayAccounts.listView-meta.xml
@@ -4,6 +4,8 @@
     <columns>ACCOUNT.NAME</columns>
     <columns>ACCOUNT.SITE</columns>
     <columns>ACCOUNT.TYPE</columns>
+    <columns>PC_EMAIL</columns>
+    <columns>ACCOUNT.PHONE1</columns>
     <columns>CORE.USERS.ALIAS</columns>
     <filterScope>Everything</filterScope>
     <filters>

--- a/src/minlopro/test/classes/duplicates-mgmt/MergeDuplicatePersonAccountsTest.cls
+++ b/src/minlopro/test/classes/duplicates-mgmt/MergeDuplicatePersonAccountsTest.cls
@@ -1,0 +1,261 @@
+/**
+ * Documentation: https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/langCon_apex_dml_examples_merge.htm
+ */
+@IsTest
+private class MergeDuplicatePersonAccountsTest {
+    static final String RULE_NAME = 'DeduplicatePersonAccounts';
+
+    @TestSetup
+    static void setup() {
+        // Verify that custom duplicate rule is active;
+        List<DuplicateRule> rules = [
+            SELECT Id
+            FROM DuplicateRule
+            WHERE DeveloperName = :RULE_NAME AND IsActive = TRUE AND SobjectType = 'Account'
+            LIMIT 1
+        ];
+        Assert.isFalse(rules.isEmpty(), String.format('{0} rule must be active!', Lists.of(RULE_NAME)));
+    }
+
+    @IsTest
+    static void testFindDuplicatesAndMergePersonAccounts() {
+        List<Account> sampleDuplicatePersonAccounts = generateSampleDuplicatePersonAccounts();
+        Assert.areEqual(3, sampleDuplicatePersonAccounts.size(), 'There should be 3 duplicate PersonAccounts pre-generated');
+
+        // User #1 creates 2 duplicate PersonAccounts;
+        User regularUser1 = TestDataFactory.createRegularUser();
+        System.runAs(regularUser1) {
+            Account pa1 = sampleDuplicatePersonAccounts[0];
+            Account pa2 = sampleDuplicatePersonAccounts[1];
+            insert new List<Account>{ pa1, pa2 };
+            pa1 = selectAccountById(pa1.Id);
+            Assert.areEqual(regularUser1.Id, pa1.OwnerId);
+            pa2 = selectAccountById(pa2.Id);
+            Assert.areEqual(regularUser1.Id, pa2.OwnerId);
+        }
+
+        // User #2 creates 1 duplicate PersonAccount with Opportunities;
+        User regularUser2 = TestDataFactory.createRegularUser();
+        System.runAs(regularUser2) {
+            Account pa3 = sampleDuplicatePersonAccounts[2];
+            insert pa3;
+            pa3 = selectAccountById(pa3.Id);
+            Assert.areEqual(regularUser2.Id, pa3.OwnerId);
+
+            List<Opportunity> testOpportunities = TestDataFactory.createOpportunities(5, pa3.Id);
+            insert testOpportunities;
+            Assert.areEqual(
+                5,
+                selectOpportunitiesByOwnerId(regularUser2.Id).size(),
+                'There should be Opportunities owned by User #2'
+            );
+            Assert.areEqual(
+                5,
+                selectOpportunitiesByAccountId(pa3.Id).size(),
+                'Opportunities should be linked to Account owned by User #2'
+            );
+        }
+
+        // Admin user finds duplicates and merges them;
+        User adminUser = TestDataFactory.createAdmin();
+        System.runAs(adminUser) {
+            Assert.areEqual(3, countPersonAccounts(), 'PersonAccount records count should be equal to 3');
+            Assert.areEqual(3, countPersonAccountContacts(), 'PersonAccount Contact records count should be equal to 3 too');
+
+            // Query PersonAccounts;
+            List<Account> personAccountsOfUser1 = selectPersonAccountsByOwnerId(regularUser1.Id);
+            Assert.areEqual(2, personAccountsOfUser1.size());
+            List<Account> personAccountsOfUser2 = selectPersonAccountsByOwnerId(regularUser2.Id);
+            Assert.areEqual(1, personAccountsOfUser2.size());
+
+            // Invoke Duplicate API;
+            List<Account> personAccountsToDeDuplicate = new List<Account>();
+            personAccountsToDeDuplicate.addAll(personAccountsOfUser1);
+            personAccountsToDeDuplicate.addAll(personAccountsOfUser2);
+            List<Datacloud.FindDuplicatesResult> foundDupResults = Datacloud.FindDuplicates.findDuplicates(
+                personAccountsToDeDuplicate
+            );
+            Assert.areEqual(3, foundDupResults.size(), '3 Duplicate Results should be found');
+            for (Datacloud.FindDuplicatesResult foundResult : foundDupResults) {
+                Assert.isTrue(foundResult.isSuccess());
+                Assert.areEqual(1, foundResult.getDuplicateResults().size());
+                Datacloud.DuplicateResult dupResult = foundResult.getDuplicateResults().get(0);
+                Assert.isFalse(dupResult.getMatchResults().isEmpty(), 'At least 1 matched result should have been found');
+            }
+
+            Account masterRecord = personAccountsOfUser1[0];
+            Account dupe1 = personAccountsOfUser1[1];
+            Account dupe2 = personAccountsOfUser2[0];
+
+            /**
+             * From Docs:
+             *  Using the Apex merge operation, field values on the master record always supersede the corresponding field values
+             *  on the records to be merged. To preserve a merged record field value, simply set this field value on the master sObject
+             *  before performing the merge.
+             */
+            masterRecord = resolveMergeFields(masterRecord, dupe1);
+            masterRecord = resolveMergeFields(masterRecord, dupe2);
+
+            // Before assertions;
+            Assert.areEqual(0, selectOpportunitiesByAccountId(masterRecord.Id).size());
+            Assert.areEqual(5, selectOpportunitiesByAccountId(dupe2.Id).size()); // User #2 Accounts with Opportunities;
+
+            // Merge PersonAccounts;
+            List<Database.MergeResult> mergeResults = Database.merge(masterRecord, new List<Account>{ dupe1, dupe2 });
+            Assert.areEqual(1, mergeResults.size(), '1 merge result is expected!');
+
+            // After assertions;
+            masterRecord = selectAccountById(masterRecord.Id);
+            Assert.areEqual(regularUser1.Id, masterRecord.OwnerId);
+            Assert.areEqual(1, countPersonAccounts(), 'PersonAccount records count should be equal to 1 after merge');
+            Assert.areEqual(
+                1,
+                countPersonAccountContacts(),
+                'PersonAccount Contact records count should be equal to 1 after merge too'
+            );
+
+            // Check whether Opportunities were re-parented;
+            Assert.areEqual(
+                5,
+                selectOpportunitiesByOwnerId(regularUser2.Id).size(),
+                'User #2 should still remain opportunities owner'
+            );
+            Assert.areEqual(
+                0,
+                selectOpportunitiesByOwnerId(regularUser1.Id).size(),
+                'User #1 should have no ownership of opportunities after merge'
+            );
+            Assert.areEqual(
+                5,
+                selectOpportunitiesByAccountId(masterRecord.Id).size(),
+                'Master PersonAccount should have opportunities linked after merge'
+            );
+
+            DebugTableFormatter logFormatter = new DebugTableFormatter(
+                new List<String>{ 'Salutation', 'FirstName', 'LastName', 'PersonEmail', 'Phone', 'Type' },
+                Lists.of(masterRecord, dupe1, dupe2)
+            );
+            logFormatter.log('=== Duplicate PersonAccounts ===');
+            Assert.isNotNull(masterRecord.Salutation);
+            Assert.isNotNull(masterRecord.FirstName);
+            Assert.isNotNull(masterRecord.LastName);
+            Assert.isNotNull(masterRecord.PersonEmail);
+            Assert.isNotNull(masterRecord.Phone);
+            Assert.isNotNull(masterRecord.Type);
+        }
+    }
+
+    static RecordTypeInfo selectPersonAccountRecordType() {
+        return Account.SObjectType.getDescribe().getRecordTypeInfosByDeveloperName().get('Customer');
+    }
+
+    static List<Account> generateSampleDuplicatePersonAccounts() {
+        // Test data should comply with 'DeduplicatePersonAccounts' duplicate/matching rule criteria;
+
+        final RecordTypeInfo personAccountRecordTypeInfo = selectPersonAccountRecordType();
+        Assert.isNotNull(personAccountRecordTypeInfo, 'PersonAccount record type undefined.');
+
+        final String COMMON_EMAIL_ADDRESS = 'pa.dupe@minlopro.edu';
+        final String COMMON_PHONE = '872-345-6789';
+
+        Account pa1 = new Account(
+            RecordTypeId = personAccountRecordTypeInfo.getRecordTypeId(),
+            Salutation = null,
+            FirstName = 'Katherine',
+            LastName = 'MACDONALD',
+            PersonEmail = COMMON_EMAIL_ADDRESS,
+            Phone = null,
+            Type = null
+        );
+        Account pa2 = new Account(
+            RecordTypeId = personAccountRecordTypeInfo.getRecordTypeId(),
+            Salutation = 'MRS',
+            FirstName = 'Katherine',
+            LastName = 'macdonald',
+            PersonEmail = COMMON_EMAIL_ADDRESS,
+            Phone = COMMON_PHONE,
+            Type = 'Customer'
+        );
+        Account pa3 = new Account(
+            RecordTypeId = personAccountRecordTypeInfo.getRecordTypeId(),
+            Salutation = 'mrs',
+            FirstName = 'Katherine',
+            LastName = 'McDonald',
+            PersonEmail = null,
+            Phone = COMMON_PHONE,
+            Type = 'Customer'
+        );
+
+        Assert.areEqual(pa1.PersonEmail, pa2.PersonEmail);
+        Assert.areEqual(pa2.Phone, pa3.Phone);
+
+        return new List<Account>{ pa1, pa2, pa3 };
+    }
+
+    static Account selectAccountById(Id accountId) {
+        return [
+            SELECT Id, Salutation, FirstName, LastName, RecordTypeId, PersonEmail, Phone, Type, IsPersonAccount, OwnerId
+            FROM Account
+            WHERE Id = :accountId
+            LIMIT 1
+        ];
+    }
+
+    static Integer countPersonAccounts() {
+        return [SELECT Id FROM Account WHERE IsPersonAccount = TRUE].size();
+    }
+
+    static Integer countPersonAccountContacts() {
+        return [SELECT Id FROM Contact WHERE IsPersonAccount = TRUE].size();
+    }
+
+    static List<Account> selectPersonAccountsByOwnerId(Id ownerId) {
+        // 'Security.stripInaccessible' removes non-writable fields prior to records merging;
+        return Security.stripInaccessible(
+                AccessType.UPSERTABLE,
+                [
+                    SELECT Id, Salutation, FirstName, LastName, RecordTypeId, PersonEmail, Phone, Type, IsPersonAccount, OwnerId
+                    FROM Account
+                    WHERE IsPersonAccount = TRUE AND OwnerId = :ownerId
+                ]
+            )
+            .getRecords();
+    }
+
+    static List<Opportunity> selectOpportunitiesByOwnerId(Id ownerId) {
+        return [
+            SELECT Id, Name, Account.Name
+            FROM Opportunity
+            WHERE OwnerId = :ownerId
+        ];
+    }
+
+    static List<Opportunity> selectOpportunitiesByAccountId(Id accountId) {
+        return [
+            SELECT Id, Name, Account.Name
+            FROM Opportunity
+            WHERE AccountId = :accountId
+        ];
+    }
+
+    static Account resolveMergeFields(Account masterRecord, Account mergeRecord) {
+        for (
+            SObjectField field : new List<SObjectField>{
+                Account.Salutation,
+                Account.FirstName,
+                Account.LastName,
+                Account.Phone,
+                Account.PersonEmail,
+                Account.Type
+            }
+        ) {
+            if (!field.getDescribe().isUpdateable()) {
+                continue;
+            }
+            if (masterRecord.get(field) == null || String.isBlank(masterRecord.get(field).toString())) {
+                masterRecord.put(field, mergeRecord.get(field));
+            }
+        }
+        return masterRecord;
+    }
+}

--- a/src/minlopro/test/classes/duplicates-mgmt/MergeDuplicatePersonAccountsTest.cls-meta.xml
+++ b/src/minlopro/test/classes/duplicates-mgmt/MergeDuplicatePersonAccountsTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
## Common Questions

**How to manually/automatically trigger DRSs record creation?** 

Scratch Org > Calling `Datacloud.FindDuplicates.findDuplicates()` DOES NOT produce DRS records. 

Looks like its triggered upon record **_insertion/update_** only.

**Run Duplicate Jobs In Lightning Experience**

Available in: _Performance and Unlimited Editions_

https://help.salesforce.com/s/articleView?id=sales.duplicate_jobs_run_and_manage.htm&type=5

Running the job produces DRS records! These can be reviewed through custom report.

Duplicate Jobs run matching rules - NOT duplicate rules.

| Setup UI | Duplicate Job Result Preview |
| ----- | ----- |
| ![image](https://github.com/user-attachments/assets/9d03e231-b243-454d-b4be-43fbb05b631d) | ![image](https://github.com/user-attachments/assets/38abcf4c-fb4b-464d-b891-7dfcca7ac486) |

**Custom Report & Report Type To Observer DRSs**

https://help.salesforce.com/s/articleView?id=sales.duplicate_management_custom_report_types.htm&type=5

**How to `merge` duplicate records in Apex?**

See `MergeDuplicatePersonAccountsTest.cls` for sample scenario.

Docs:
- https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/langCon_apex_dml_examples_merge.htm
- https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_triggers_merge_statements.htm

Outstanding limitations:
-  You can merge up to _three_ records of the same sObject type. The `merge` operation merges up to three records into one of the records, deletes the others, and _reparents_ any related records.
- Using the Apex `merge` operation, field values on the master record always supersede the corresponding field values on the records to be merged. To preserve a merged record field value, simply set this field value on the master sObject before performing the merge.

